### PR TITLE
environment path should point to the symbolic link

### DIFF
--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -405,7 +405,7 @@ class Chef
           return
         end
 
-        new_path = ::File.join(new_resource.path, 'bin')
+        new_path = ::File.join(new_resource.home_dir, 'bin')
         Chef::Log.debug("new_path is #{new_path}")
         path = "/etc/profile.d/#{new_resource.name}.sh"
         f = Chef::Resource::File.new(path, run_context)


### PR DESCRIPTION
Hi,

I was thinking the /etc/profile.d/environment.sh file should add the home_dir (symbolic path) and not the absolute path

Thanks,
Keenan
