### PR TITLE
do not download if release_file exists locally

### DIFF
--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -32,7 +32,7 @@ class Chef
         unless new_resource.url =~ /^(http|ftp).*$/
             new_resource.url = set_apache_url(url)
         end
-        unless unpacked? new_resource.path
+        unless ::File.exists?(new_resource.release_file) or unpacked?(new_resource.path)
           f = Chef::Resource::RemoteFile.new(new_resource.release_file, run_context)
           f.source new_resource.url
           if new_resource.checksum
@@ -254,7 +254,7 @@ class Chef
         new_resource.path       = ::File.join(prefix_root, "#{new_resource.name}-#{new_resource.version}")
         new_resource.home_dir ||= default_home_dir
         Chef::Log.debug("path is #{new_resource.path}")
-        new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}.#{release_ext}")
+        new_resource.release_file     ||= ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}.#{release_ext}")
       end
 
       def set_put_paths


### PR DESCRIPTION
Hi,

If the file exists locally, it would be nice to not download the file again.

Personally, I am pointing to an already downloaded file. So I don't want it to go out and link.
Also, if the person declared the local file, don't overwrite it.

Thanks for a great library,
Keenan
