### PR TITLE
Allow to ignore version attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Attribute Parameters
   and `.zip` currently supported. Also supports special syntax
   `:name:version:apache_mirror:` that will auto-magically construct
   download url from the apache mirrors site.
-- `version`: software version, defaults to `1`.
+- `version`: software version, defaults to `1`. `false` will be ignored in the path
 - `checksum`: sha256 checksum, used for security .
 - `mode`: file mode for `app_home`, is an integer.
 - `prefix_root`: default `prefix_root`, for use with `:install*`

--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -250,8 +250,8 @@ class Chef
         end
         # set effective paths
         new_resource.prefix_bin = prefix_bin
-        new_resource.version ||= "1"  # initialize to one if nil
-        new_resource.path       = ::File.join(prefix_root, "#{new_resource.name}-#{new_resource.version}")
+        new_resource.version ||= "1" if version != true  # initialize to one if nil
+        new_resource.path       = ::File.join(prefix_root, [new_resource.name, new_resource.version].compact.join('-'))
         new_resource.home_dir ||= default_home_dir
         Chef::Log.debug("path is #{new_resource.path}")
         new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}.#{release_ext}")


### PR DESCRIPTION
From some reason I need to ignore the version format in a path. This allows to ignore it using false
