### PR TITLE
[COOK-2207] Remove mode attribute and leave permissions alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ NOTE: This currently only works for zip archives
 ### Attribute Parameters for :dump
 
 - `path`: path to dump files to.
-- `mode`: file mode for `app_home`, as an integer.
-  - Example: `0775`
 - `creates`: if you are appending files to a given directory, ark
   needs a condition to test whether the file has already been
   extracted. You can specify with creates, a file whose existence
@@ -120,7 +118,6 @@ Attribute Parameters
   download url from the apache mirrors site.
 - `version`: software version, defaults to `1`.
 - `checksum`: sha256 checksum, used for security .
-- `mode`: file mode for `app_home`, is an integer.
 - `prefix_root`: default `prefix_root`, for use with `:install*`
   actions.
 - `prefix_home`: default directory prefix for a friendly symlink to

--- a/libraries/provider_ark.rb
+++ b/libraries/provider_ark.rb
@@ -192,7 +192,6 @@ class Chef
       def action_set_owner(path)
         require 'fileutils'
         FileUtils.chown_R new_resource.owner, new_resource.group, path
-        FileUtils.chmod_R new_resource.mode, path
       end
 
       def action_install_binaries

--- a/libraries/resource_ark.rb
+++ b/libraries/resource_ark.rb
@@ -45,7 +45,6 @@ class Chef
       attribute :creates, :kind_of => String, :default => nil
       attribute :release_file, :kind_of => String, :default => ''
       attribute :strip_leading_dir, :kind_of => [TrueClass, FalseClass], :default => true
-      attribute :mode, :kind_of => Fixnum, :default => 0755
       attribute :prefix_root, :kind_of => String, :default => nil
       attribute :prefix_home, :kind_of => String, :default => nil
       attribute :prefix_bin, :kind_of => String, :default => nil


### PR DESCRIPTION
Though I haven't tested, removing L195 in `provider_ark.rb` should fix the issue. Also, this line was the only use of the `mode` attribute, so I removed it as well.
