### PR TITLE
FileUtils.mv fails when moving symbolic links

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -305,7 +305,10 @@ def unzip
         subdir = subdirectory_children[0]
         subdirectory_children = Dir.glob("#{subdir}/**")
       end
-      FileUtils.mv subdirectory_children, new_resource.path
+      subdirectory_children.each do |source|
+        Chef::Log.info("move #{source} --> #{new_resource.path}")
+        system('mv', source, new_resource.path)
+      end    
       FileUtils.rm_rf tmpdir
     else
       cmd = Mixlib::ShellOut.new("unzip  -q -u -o #{new_resource.release_file} -d #{new_resource.path}")


### PR DESCRIPTION
- opscode bug: COOK-2480
- ruby-trunk bug: #7707

Change FileUtils.mv with system 'mv' to prevent Errno::ENOENT: No such file or directory
when trying to move symbolic links
