### PR TITLE
Expose HTTP headers support from remote_file provider

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -45,7 +45,7 @@ action :install do
     Chef::Log.debug("DEBUG: new_resource.release_file")
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end
+    if new_resource.http_headers then headers new_resource.http_headers end
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
@@ -117,7 +117,7 @@ action :put do
   remote_file new_resource.release_file do
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end
+    if new_resource.http_headers then headers new_resource.http_headers end
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
@@ -156,7 +156,7 @@ action :dump do
     Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end
+    if new_resource.http_headers then headers new_resource.http_headers end
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
@@ -195,7 +195,7 @@ action :unzip do
     Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end      
+    if new_resource.http_headers then headers new_resource.http_headers end      
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
@@ -234,7 +234,7 @@ action :cherry_pick do
   remote_file new_resource.release_file do
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end 
+    if new_resource.http_headers then headers new_resource.http_headers end 
     action :create
     notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
   end
@@ -273,7 +273,7 @@ action :install_with_make do
     Chef::Log.debug("DEBUG: new_resource.release_file")
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end  
+    if new_resource.http_headers then headers new_resource.http_headers end  
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
@@ -342,7 +342,7 @@ action :configure do
     Chef::Log.debug("DEBUG: new_resource.release_file")
     source new_resource.url
     if new_resource.checksum then checksum new_resource.checksum end
-    if new_resource.headers then headers new_resource.headers end
+    if new_resource.http_headers then headers new_resource.http_headers end
     action :create
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,7 +35,7 @@ attribute :path, :kind_of => String, :default => nil
 attribute :full_path, :kind_of => String, :default => nil
 attribute :append_env_path, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :checksum, :regex => /^[a-zA-Z0-9]{64}$/, :default => nil
-attribute :headers, :kind_of => Hash, :default => nil
+attribute :http_headers, :kind_of => Hash, :default => nil
 attribute :has_binaries, :kind_of => Array, :default => []
 attribute :creates, :kind_of => String, :default => nil
 attribute :release_file, :kind_of => String, :default => ''


### PR DESCRIPTION
This way basic auth is supported when downloading archives.
