### PR TITLE
Attributes defined by user should not be overrided by ark defaults

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -116,7 +116,7 @@ module Opscode
         new_resource.path       = ::File.join(prefix_root, "#{new_resource.name}-#{new_resource.version}")
         new_resource.home_dir ||= default_home_dir
         Chef::Log.debug("path is #{new_resource.path}")
-        new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}.#{release_ext}")
+        new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}-#{new_resource.version}.#{release_ext}")
       end
 
       def set_put_paths


### PR DESCRIPTION
This patch preserves path and release_file specified by user. Previous implementation uses ARK default values each time, it does not matter if user specifies his own attributes or not.
