### PR TITLE
COOK-3786: Unable to install multiple versions of application using Ark cookbook to directories without duplicated version

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -116,7 +116,7 @@ module Opscode
         new_resource.path       = ::File.join(prefix_root, "#{new_resource.name}-#{new_resource.version}")
         new_resource.home_dir ||= default_home_dir
         Chef::Log.debug("path is #{new_resource.path}")
-        new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}.#{release_ext}")
+        new_resource.release_file     = ::File.join(Chef::Config[:file_cache_path],  "#{new_resource.name}-#{new_resource.version}.#{release_ext}")
       end
 
       def set_put_paths


### PR DESCRIPTION
All version are now downloaded to separate files (as archive
filename now contains version number), so each extracted
folder now contains data from correct archive file, not from
latest download to same location.
