### PR TITLE
Add node['ark']['package_dependencies'] to allow tuning packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ defaults.
   `prefix_bin` is not passed into the resource.
 * `node['ark']['prefix_home']` - default home location if the
   `prefix_home` is not passed into the resource.
+* `node['ark']['package_dependencies']` - prerequisite system
+  packages that need to be installed to support ark.
 
 Resources/Providers
 ===================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,3 +3,10 @@ default['ark']['prefix_root'] = '/usr/local'
 default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
 default['ark']['tar'] = '/bin/tar'
+
+pkgs = %w(libtool autoconf)
+pkgs += %w(unzip rsync make gcc) unless platform_family?('mac_os_x')
+pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x')
+pkgs += %w(gtar) if platform?('freebsd')
+
+default['ark']['package_dependencies'] = pkgs

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,11 +18,6 @@
 # limitations under the License.
 #
 
-package 'unzip'
-package 'libtool'
-package 'rsync'
-package 'autoconf'
-package 'make'
-package 'gcc'
-package 'autogen' unless platform_family?('rhel', 'fedora')
-package 'gtar' if platform?('freebsd')
+Array(node['ark']['package_dependencies']).each do |pkg|
+  package pkg
+end


### PR DESCRIPTION
> **Tracking as [COOK-4264](https://tickets.opscode.com/browse/COOK-4264)**

Currently it is difficult to install ark on systems that cannot install
the packages in the default recipe. Rather than a collection of Chef
resources a configurable Array of package names should make this
cookbook more resilient to new platforms in the future.
