### PR TITLE
fix syntax error

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -39,7 +39,7 @@ attribute :has_binaries, :kind_of => Array, :default => []
 attribute :creates, :kind_of => String, :default => nil
 attribute :release_file, :kind_of => String, :default => ''
 attribute :strip_leading_dir, :kind_of => [TrueClass, FalseClass, NilClass]
-attribute :strip_components, :kind_of => Integer, default: 1
+attribute :strip_components, :kind_of => Integer, :default => 1
 attribute :mode, :kind_of => Fixnum, :default => 0755
 attribute :prefix_root, :kind_of => String, :default => nil
 attribute :prefix_home, :kind_of => String, :default => nil


### PR DESCRIPTION
Fixes this error message on vagrant box:
## SyntaxError

compile error
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/ark/resources/default.rb:42: syntax error, unexpected ':', expecting tASSOC
attribute :strip_components, :kind_of => Integer, default: 1
                                                          ^
