### PR TITLE
update README.md details about local file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ By default, the ark will not run again if the `:path` is not empty.
 Ark provides many actions to accommodate different use cases, such as
 `:dump`, `:cherry_pick`, `:put`, and `:install_with_make`.
 
-At this time ark only handles files available from URLs. It does not
-handle local files.
+At this time ark only handles files available from URLs using the
+[remote_file](http://docs.opscode.com/resource_remote_file.html) provider.
+It does handle local files using the `file://` protocol.
 
 Requirements
 ============


### PR DESCRIPTION
Just tried that file:// protocol works OK in the url attribute, as the provider relies in remote_file the documentation was wrong about not supporting local files.

This was my test case.

```
ark "phoenix" do
  url "file://#{Chef::Config[:file_cache_path]}/phoenix.tar.gz"
  version '2.2.3'
end
```
