### PR TITLE
Remove mention of checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Attribute Parameters
   `:name:version:apache_mirror:` that will auto-magically construct
   download url from the apache mirrors site.
 - `version`: software version, defaults to `1`.
-- `checksum`: sha256 checksum, used for security .
 - `mode`: file mode for `app_home`, is an integer.
 - `prefix_root`: default `prefix_root`, for use with `:install*`
   actions.


### PR DESCRIPTION
The checksum attribute of ark is just passed on to remote_file.  remote_file uses this to detect changes and prevent unnecessary downloads.  Unfortunately, it does not use it for security.

Obvious change.
