### PR TITLE
[COOK-3642] Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ defaults.
   `prefix_bin` is not passed into the resource.
 * `node['ark']['prefix_home']` - default home location if the
   `prefix_home` is not passed into the resource.
+* `node['ark']['win_install_dir']` - directory where the files will
+  be put on windows
 * `node['ark']['package_dependencies']` - prerequisite system
   packages that need to be installed to support ark.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,11 +2,15 @@ default['ark']['apache_mirror'] = 'http://apache.mirrors.tds.net'
 default['ark']['prefix_root'] = '/usr/local'
 default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
-default['ark']['tar'] = '/bin/tar'
+if node['platform_family'] === 'windows'
+  default['ark']['tar'] = "\"#{default['7-zip']['home']}\\7z.exe\""
+else
+  default['ark']['tar'] = '/bin/tar'
+end
 
-pkgs = %w(libtool autoconf)
-pkgs += %w(unzip rsync make gcc) unless platform_family?('mac_os_x')
-pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x', 'suse')
+pkgs = %w(libtool autoconf) unless platform_family?('mac_os_x','windows')
+pkgs += %w(unzip rsync make gcc) unless platform_family?('mac_os_x','windows')
+pkgs += %w(autogen) unless platform_family?('rhel', 'fedora', 'mac_os_x', 'suse','windows')
 pkgs += %w(gtar) if platform?('freebsd')
 
 default['ark']['package_dependencies'] = pkgs

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,11 @@ description      'Installs/Configures ark'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.8.3'
 
-%w( debian ubuntu centos redhat fedora ).each do |os|
+%w( debian ubuntu centos redhat fedora windows ).each do |os|
   supports os
 end
 
 recipe 'ark::default', 'Installs and configures ark'
+
+depends 'windows'
+depends '7-zip'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -61,33 +61,37 @@ action :install do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 
-  # symlink binaries
-  new_resource.has_binaries.each do |bin|
-    link ::File.join(new_resource.prefix_bin, ::File.basename(bin)) do
-      to ::File.join(new_resource.path, bin)
+  # usually on windows there is no central directory with executables where the applciations are linked
+  if not node['platform_family'] === 'windows'
+    # symlink binaries
+    new_resource.has_binaries.each do |bin|
+      link ::File.join(new_resource.prefix_bin, ::File.basename(bin)) do
+        to ::File.join(new_resource.path, bin)
+      end
     end
-  end
 
-  # action_link_paths
-  link new_resource.home_dir do
-    to new_resource.path
-  end
+    # action_link_paths
+    link new_resource.home_dir do
+      to new_resource.path
+    end
 
-  # Add to path for interactive bash sessions
-  template "/etc/profile.d/#{new_resource.name}.sh" do
-    cookbook 'ark'
-    source 'add_to_path.sh.erb'
-    owner 'root'
-    group 'root'
-    mode '0755'
-    cookbook 'ark'
-    variables(:directory => "#{new_resource.path}/bin")
-    only_if { new_resource.append_env_path }
+    # Add to path for interactive bash sessions
+    template "/etc/profile.d/#{new_resource.name}.sh" do
+      cookbook 'ark'
+      source 'add_to_path.sh.erb'
+      owner 'root'
+      group 'root'
+      mode '0755'
+      cookbook 'ark'
+      variables(:directory => "#{new_resource.path}/bin")
+      only_if { new_resource.append_env_path }
+    end
   end
 
   # Add to path for the current chef-client converge.
@@ -132,8 +136,9 @@ action :put do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 end
@@ -171,8 +176,9 @@ action :dump do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 end
@@ -210,8 +216,9 @@ action :unzip do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 end
@@ -249,8 +256,9 @@ action :cherry_pick do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 end
@@ -291,8 +299,9 @@ action :install_with_make do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 
@@ -362,8 +371,9 @@ action :configure do
   end
 
   # set_owner
+  _owner_command = owner_command
   execute "set owner on #{new_resource.path}" do
-    command "chown -R #{new_resource.owner}:#{new_resource.group} #{new_resource.path}"
+    command _owner_command
     action :nothing
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,3 +21,7 @@
 Array(node['ark']['package_dependencies']).each do |pkg|
   package pkg
 end
+
+if node['platform_family'] === 'windows'
+  include_recipe "7-zip"
+end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -46,6 +46,7 @@ attribute :prefix_home, :kind_of => String, :default => nil
 attribute :prefix_bin, :kind_of => String, :default => nil
 attribute :version, :kind_of => String, :default => nil
 attribute :home_dir, :kind_of => String, :default => nil
+attribute :win_install_dir, :kind_of => String, :default => nil
 attribute :environment, :kind_of => Hash, :default => {}
 attribute :autoconf_opts, :kind_of => Array, :default => []
 attribute :make_opts, :kind_of => Array, :default => []


### PR DESCRIPTION
This pull request adds windows support to the ark package. It makes use
of the 7-zip cookbook to download and install 7-zip on windows to
extract the files.
As files are handled a little different on windows then on unix systems
a new parameter 'win_install_dir' is introduced. To this folder the
files are extracted to.
Unfortunately, there is no windows system in the kitchen config, so this
cannot be tested automatically, but tests were done.

Ticket: https://tickets.opscode.com/browse/COOK-3642
