### PR TITLE
Declare windows & 7-zip cookbooks "suggests" rather than "depends"

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,5 +15,6 @@ supported_operating_systems.each { |os| supports os }
 recipe 'ark::default', 'Installs and configures ark'
 
 depends 'build-essential'
-depends 'windows'
-depends '7-zip'
+
+suggests 'windows' # for windows os
+suggests '7-zip' # for windows os


### PR DESCRIPTION
With the latest version of the ark cookbook, we began running into the same 7-zip cookbook naming error as is documented here:

https://tickets.opscode.com/browse/COOK-4032

Given that we're not using ark for doing anything with windows, we changed windows & 7-zip to "suggests" and things are working as expected for our Linux based builds again.

The practice of declaring OS-specific cookbook dependencies as "suggests" is not uncommon, and is seen in other popular cookbooks such as java and build-essential.

https://github.com/agileorbit-cookbooks/java/blob/master/metadata.rb
https://github.com/opscode-cookbooks/build-essential/blob/master/metadata.rb
