### PR TITLE
Fix issue #107 by adding a new attribute clean_up_before_unpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Attribute Parameters
   - Example: `[ '--warn-undefined-variables', '--load-average=2' ]`
 - `owner`: owner of extracted directory.
   - Default: `root`
+- `clean_up_before_unpack`: when set to true, the content of the directory defined by `path`
+  is deleted before to unpack the archive (and only if an unpack operation will be performed). 
+  This is usefull to ensure a clean directory content after ark execution when the remote archive 
+  has  been updated since previous chef-client run whereas its version is left unchanged.
+  - Default: `false` 
 
 ### Examples
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -35,6 +35,7 @@ action :install do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -120,6 +121,7 @@ action :put do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -167,6 +169,7 @@ action :dump do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -215,6 +218,7 @@ action :unzip do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -264,6 +268,7 @@ action :cherry_pick do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
   end
 
@@ -309,6 +314,7 @@ action :install_with_make do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -389,6 +395,7 @@ action :setup_py_build do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -441,6 +448,7 @@ action :setup_py_install do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -493,6 +501,7 @@ action :setup_py do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -545,6 +554,7 @@ action :configure do
   directory new_resource.path do
     recursive true
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -38,11 +38,21 @@ action :install do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -113,11 +123,21 @@ action :put do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   # download
   remote_file new_resource.release_file do
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -150,12 +170,22 @@ action :dump do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   # download
   remote_file new_resource.release_file do
     Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -188,12 +218,22 @@ action :unzip do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   # download
   remote_file new_resource.release_file do
     Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -227,11 +267,21 @@ action :cherry_pick do
     notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   # download
   remote_file new_resource.release_file do
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
   end
 
@@ -262,11 +312,21 @@ action :install_with_make do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -332,11 +392,21 @@ action :setup_py_build do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -374,11 +444,21 @@ action :setup_py_install do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -416,11 +496,21 @@ action :setup_py do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -458,11 +548,21 @@ action :configure do
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
+  # clean up existing path content if requested
+  ruby_block "clean up #{new_resource.path} before unpack" do
+    block do
+      delete_files_and_directories_inside(new_resource.path)
+    end
+    action :nothing
+    only_if { new_resource.clean_up_before_unpack }
+  end
+
   remote_file new_resource.release_file do
     Chef::Log.debug('DEBUG: new_resource.release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
+    notifies :run, "ruby_block[clean up #{new_resource.path} before unpack]"
     notifies :run, "execute[unpack #{new_resource.release_file}]"
   end
 
@@ -498,5 +598,16 @@ action :configure do
     cwd new_resource.path
     environment new_resource.environment
     action :nothing
+  end
+end
+
+# Delete all files and directories inside the given directory.
+# @param path Path of the directory.
+def delete_files_and_directories_inside(path)
+  # Ensure to have only / in path (windows path separator is not supported by Dir)
+  directory_content_pattern = ::File.join(new_resource.path, "*").gsub(%r:\\:, "/")
+
+  ::Dir[directory_content_pattern].each do |path|
+    ::FileUtils.rm_rf path
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -66,3 +66,4 @@ attribute :make_opts, kind_of: Array, default: []
 attribute :home_dir, kind_of: String, default: nil
 attribute :autoconf_opts, kind_of: Array, default: []
 attribute :extension, kind_of: String
+attribute :clean_up_before_unpack, kind_of: [TrueClass, FalseClass], default: false

--- a/spec/fixtures/cookbooks/ark_spec/recipes/cherry_pick_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/cherry_pick_with_clean_up_before_unpack.rb
@@ -1,0 +1,11 @@
+
+ark 'test_cherry_pick' do
+  url 'https://github.com/chef-cookbooks/ark/raw/master/files/default/foo.tar.gz'
+  checksum '5996e676f17457c823d86f1605eaa44ca8a81e70d6a0e5f8e45b51e62e0c52e8'
+  path '/usr/local/foo_cherry_pick'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  creates 'foo_sub/foo1.txt'
+  action :cherry_pick
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/configure_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/configure_with_clean_up_before_unpack.rb
@@ -1,0 +1,7 @@
+
+ark 'test_configure' do
+  url 'https://github.com/zeromq/libzmq/tarball/master'
+  extension 'tar.gz'
+  action :configure
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/dump_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/dump_with_clean_up_before_unpack.rb
@@ -1,0 +1,11 @@
+
+ark 'test_dump' do
+  url 'https://github.com/chef-cookbooks/ark/raw/master/files/default/foo.zip'
+  checksum 'deea3a324115c9ca0f3078362f807250080bf1b27516f7eca9d34aad863a11e0'
+  path '/usr/local/foo_dump'
+  creates 'foo1.txt'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  action :dump
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/install_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/install_with_clean_up_before_unpack.rb
@@ -1,0 +1,11 @@
+
+ark 'test_install' do
+  url 'https://github.com/chef-cookbooks/ark/raw/master/files/default/foo.tar.gz'
+  checksum '5996e676f17457c823d86f1605eaa44ca8a81e70d6a0e5f8e45b51e62e0c52e8'
+  version '2'
+  prefix_root '/usr/local'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  action :install
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/install_with_make_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/install_with_make_with_clean_up_before_unpack.rb
@@ -1,0 +1,9 @@
+
+ark 'test_install_with_make' do
+  url 'http://haproxy.1wt.eu/download/1.5/src/snapshot/haproxy-ss-20120403.tar.gz'
+  version '1.5'
+  checksum 'ba0424bf7d23b3a607ee24bbb855bb0ea347d7ffde0bec0cb12a89623cbaf911'
+  make_opts ['TARGET=linux26']
+  action :install_with_make
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/put_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/put_with_clean_up_before_unpack.rb
@@ -1,0 +1,8 @@
+
+ark 'test_put' do
+  url 'https://github.com/chef-cookbooks/ark/raw/master/files/default/foo.tar.gz'
+  checksum '5996e676f17457c823d86f1605eaa44ca8a81e70d6a0e5f8e45b51e62e0c52e8'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  action :put
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_build_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_build_with_clean_up_before_unpack.rb
@@ -1,0 +1,6 @@
+ark 'test_setup_py_build' do
+  url 'https://codeload.github.com/s3tools/s3cmd/tar.gz/master'
+  extension 'tar.gz'
+  action :setup_py_build
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_install_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_install_with_clean_up_before_unpack.rb
@@ -1,0 +1,6 @@
+ark 'test_setup_py_install' do
+  url 'https://codeload.github.com/s3tools/s3cmd/tar.gz/master'
+  extension 'tar.gz'
+  action :setup_py_install
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/setup_py_with_clean_up_before_unpack.rb
@@ -1,0 +1,6 @@
+ark 'test_setup_py' do
+  url 'https://codeload.github.com/s3tools/s3cmd/tar.gz/master'
+  extension 'tar.gz'
+  action :setup_py
+  clean_up_before_unpack true
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/unzip_with_clean_up_before_unpack.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/unzip_with_clean_up_before_unpack.rb
@@ -1,0 +1,11 @@
+
+ark 'test_unzip' do
+  url 'https://github.com/chef-cookbooks/ark/raw/master/files/default/foo.zip'
+  checksum 'deea3a324115c9ca0f3078362f807250080bf1b27516f7eca9d34aad863a11e0'
+  path '/usr/local/foo_dump'
+  creates 'foo1.txt'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  action :unzip
+  clean_up_before_unpack true
+end

--- a/spec/recipes/windows/default_spec.rb
+++ b/spec/recipes/windows/default_spec.rb
@@ -11,7 +11,7 @@ describe_recipe "ark::default" do
   # as a suggestion or recommendation the attributes are not proprerly loaded
   # unless the recipe is on the run_list.
   #
-  let(:chef_run) { ChefSpec::Runner.new(node_attributes).converge("7-zip", described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(node_attributes).converge("7-zip", described_recipe) }
 
   let(:expected_packages) do
     %w( libtool autoconf unzip rsync make gcc autogen xz-lzma-compat )

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -182,6 +182,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to install_ark("test_install")
 
+      resource = chef_run.directory("/usr/local/test_install-2")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_install-2 before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_install-2.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_install-2 before unpack]")
     end
@@ -216,6 +219,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to put_ark("test_put")
 
+      resource = chef_run.directory("/usr/local/test_put")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_put before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_put.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_put before unpack]")
     end
@@ -249,6 +255,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to dump_ark("test_dump")
 
+      resource = chef_run.directory("/usr/local/foo_dump")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_dump.zip")
       expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
     end
@@ -281,6 +290,9 @@ describe_resource "ark" do
 
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to unzip_ark("test_unzip")
+
+      resource = chef_run.directory("/usr/local/foo_dump")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
 
       resource = chef_run.remote_file("/var/chef/cache/test_unzip.zip")
       expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
@@ -317,6 +329,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to cherry_pick_ark("test_cherry_pick")
 
+      resource = chef_run.directory("/usr/local/foo_cherry_pick")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_cherry_pick before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_cherry_pick.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/foo_cherry_pick before unpack]")
     end
@@ -352,6 +367,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to setup_py_build_ark("test_setup_py_build")
 
+      resource = chef_run.directory("/usr/local/test_setup_py_build-1")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_build-1 before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_setup_py_build-1.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_build-1 before unpack]")
     end
@@ -384,6 +402,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to setup_py_install_ark("test_setup_py_install")
 
+      resource = chef_run.directory("/usr/local/test_setup_py_install-1")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_install-1 before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_setup_py_install-1.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_install-1 before unpack]")
     end
@@ -415,6 +436,9 @@ describe_resource "ark" do
 
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to setup_py_ark("test_setup_py")
+
+      resource = chef_run.directory("/usr/local/test_setup_py-1")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py-1 before unpack]")
 
       resource = chef_run.remote_file("/var/chef/cache/test_setup_py-1.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py-1 before unpack]")
@@ -458,6 +482,9 @@ describe_resource "ark" do
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to install_with_make_ark("test_install_with_make")
 
+      resource = chef_run.directory("/usr/local/test_install_with_make-1.5")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_install_with_make-1.5 before unpack]")
+
       resource = chef_run.remote_file("/var/chef/cache/test_install_with_make-1.5.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_install_with_make-1.5 before unpack]")
     end
@@ -496,6 +523,9 @@ describe_resource "ark" do
 
     it "cleans up target directory before to unpack the archive" do
       expect(chef_run).to configure_ark("test_configure")
+
+      resource = chef_run.directory("/usr/local/test_configure-1")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_configure-1 before unpack]")
 
       resource = chef_run.remote_file("/var/chef/cache/test_configure-1.tar.gz")
       expect(resource).to notify("ruby_block[clean up /usr/local/test_configure-1 before unpack]")

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -7,7 +7,7 @@ describe_resource "ark" do
     Chef::Config[:file_cache_path] = "/var/chef/cache"
   end
 
-  describe "install" do
+  describe "install", wip: true do
 
     let(:example_recipe) { "ark_spec::install" }
 
@@ -144,7 +144,7 @@ describe_resource "ark" do
     let(:example_recipe) { "ark_spec::install_windows" }
 
     def node_attributes
-      { platform: "windows", version: "2008R2" }
+      { platform: "windows", version: "2008R2", file_cache_path: "/var/chef/cache" }
     end
 
     it "installs" do
@@ -175,7 +175,20 @@ describe_resource "ark" do
     end
   end
 
-  describe "put" do
+  describe "install with clean_up_before_unpack == true", wip: true do
+
+    let(:example_recipe) { "ark_spec::install_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to install_ark("test_install")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_install-2.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_install-2 before unpack]")
+    end
+
+  end
+
+  describe "put", wip: true do
 
     let(:example_recipe) { "ark_spec::put" }
 
@@ -192,6 +205,19 @@ describe_resource "ark" do
 
       expect(chef_run).to_not run_execute("unpack /var/chef/cache/test_put.tar.gz")
       expect(chef_run).to_not run_execute("set owner on /usr/local/test_put")
+    end
+
+  end
+
+  describe "put with clean_up_before_unpack == true", wip: true do
+
+    let(:example_recipe) { "ark_spec::put_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to put_ark("test_put")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_put.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_put before unpack]")
     end
 
   end
@@ -216,6 +242,19 @@ describe_resource "ark" do
     end
   end
 
+  describe "dump with clean_up_before_unpack == true", wip: true do
+
+    let(:example_recipe) { "ark_spec::dump_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to dump_ark("test_dump")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_dump.zip")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
+    end
+
+  end
+
   describe "unzip" do
 
     let(:example_recipe) { "ark_spec::unzip" }
@@ -233,6 +272,18 @@ describe_resource "ark" do
 
       expect(chef_run).to_not run_execute("unpack /var/chef/cache/test_unzip.zip")
       expect(chef_run).to_not run_execute("set owner on /usr/local/foo_dump")
+    end
+  end
+
+  describe "unzip with clean_up_before_unpack == true", wip: true do
+
+    let(:example_recipe) { "ark_spec::unzip_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to unzip_ark("test_unzip")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_unzip.zip")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_dump before unpack]")
     end
   end
 
@@ -260,6 +311,17 @@ describe_resource "ark" do
     end
   end
 
+  describe "cherry_pîck with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::cherry_pick_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to cherry_pick_ark("test_cherry_pick")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_cherry_pick.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/foo_cherry_pick before unpack]")
+    end
+  end
+
   describe "setup_py_build" do
     let (:example_recipe) { "ark_spec::setup_py_build" }
 
@@ -284,6 +346,17 @@ describe_resource "ark" do
     end
   end
 
+  describe "setup_py_build with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::setup_py_build_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to setup_py_build_ark("test_setup_py_build")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_setup_py_build-1.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_build-1 before unpack]")
+    end
+  end
+
   describe "setup_py_install" do
     let (:example_recipe) { "ark_spec::setup_py_install" }
 
@@ -305,6 +378,17 @@ describe_resource "ark" do
     end
   end
 
+  describe "setup_py_install with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::setup_py_install_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to setup_py_install_ark("test_setup_py_install")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_setup_py_install-1.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py_install-1 before unpack]")
+    end
+  end
+
   describe "setup_py" do
     let (:example_recipe) { "ark_spec::setup_py" }
 
@@ -323,6 +407,17 @@ describe_resource "ark" do
 
       expect(chef_run).not_to run_execute("set owner on /usr/local/test_setup_py")
       expect(chef_run).not_to run_execute("python setup.py /usr/local/test_setup_py")
+    end
+  end
+
+  describe "setup_py with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::setup_py_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to setup_py_ark("test_setup_py")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_setup_py-1.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_setup_py-1 before unpack]")
     end
   end
 
@@ -357,6 +452,17 @@ describe_resource "ark" do
     end
   end
 
+  describe "install_with_make with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::install_with_make_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to install_with_make_ark("test_install_with_make")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_install_with_make-1.5.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_install_with_make-1.5 before unpack]")
+    end
+  end
+
   describe "configure" do
 
     let(:example_recipe) { "ark_spec::configure" }
@@ -385,4 +491,14 @@ describe_resource "ark" do
     end
   end
 
+  describe "configure with clean_up_before_unpack == true", wip: true do
+    let(:example_recipe) { "ark_spec::configure_with_clean_up_before_unpack" }
+
+    it "cleans up target directory before to unpack the archive" do
+      expect(chef_run).to configure_ark("test_configure")
+
+      resource = chef_run.remote_file("/var/chef/cache/test_configure-1.tar.gz")
+      expect(resource).to notify("ruby_block[clean up /usr/local/test_configure-1 before unpack]")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ end
 
 RSpec.shared_context "recipe tests", type: :recipe do
 
-  let(:chef_run) { ChefSpec::Runner.new(node_attributes).converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(node_attributes).converge(described_recipe) }
 
   let(:node) { chef_run.node }
 
@@ -76,7 +76,7 @@ end
 RSpec.shared_context "resource tests", type: :resource do
 
   let(:chef_run) do
-    ChefSpec::Runner.new(node_attributes.merge(step_into)).converge(example_recipe)
+    ChefSpec::SoloRunner.new(node_attributes.merge(step_into)).converge(example_recipe)
   end
 
   let(:example_recipe) do
@@ -93,7 +93,7 @@ Please specify the name of the test recipe that executes your recipe:
   let(:node) { chef_run.node }
 
   def node_attributes
-    {}
+    { file_cache_path: '/var/chef/cache' }
   end
 
   let(:step_into) do


### PR DESCRIPTION
All ark actions support a new attribute, **clean_up_before_unpack**. When set to true, the content of the target directory is removed before the updated archive is unpacked.

By default, the attribute is false in order to keep the previous behaviour (no deletion of target directory on unpack).
