### PR TITLE
save a directory tree in case of zip archives

### DIFF
--- a/libraries/unzip_command_builder.rb
+++ b/libraries/unzip_command_builder.rb
@@ -33,7 +33,7 @@ module Ark
 
     def unzip_with_strip_components
       tmpdir = make_temp_directory
-      strip_dir = '*/' * resource.strip_components
+      strip_dir = '*' * resource.strip_components
       cmd = "unzip -q -o #{resource.release_file} -d #{tmpdir}"
       cmd += " && rsync -a #{tmpdir}/#{strip_dir} #{resource.path}"
       cmd += " && rm -rf #{tmpdir}"

--- a/spec/libraries/unzip_command_builder_spec.rb
+++ b/spec/libraries/unzip_command_builder_spec.rb
@@ -32,7 +32,7 @@ describe Ark::UnzipCommandBuilder do
       end
 
       it "generates the correct command" do
-        expected_command = "unzip -q -o release_file -d temp_directory && rsync -a temp_directory/*/ path && rm -rf temp_directory"
+        expected_command = "unzip -q -o release_file -d temp_directory && rsync -a temp_directory/* path && rm -rf temp_directory"
         allow(subject).to receive(:make_temp_directory) { "temp_directory" }
         expect(subject.unpack).to eq(expected_command)
       end


### PR DESCRIPTION
In current implementation, cookbook unzips archive and directory tree loses, all files are in root folder without sub folders.
