### PR TITLE
[GH-196] Add of whyrun support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,6 @@ matrix:
   include:
     - script:
       - chef exec delivery local all
-      env: UNIT_AND_LINT=1
+      env: 
+      - UNIT_AND_LINT=1
+      - CHEF_LICENSE=accept

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Extract the archive to a specified path, does not create any symbolic links.
 
   - Default: `5`
 
+N.B. Some attributes, prefixed by '_', are reserved to ark resource internal implementation. Setting anyone of them wouldn't have any effect.
+
 #### Examples
 
 This example copies `ivy.tar.gz` to `/var/cache/chef/ivy-2.2.0.tar.gz`, unpacks its contents to `/usr/local/ivy-2.2.0/` -- stripping the leading directory, and symlinks `/usr/local/ivy` to `/usr/local/ivy-2.2.0`

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept
   deprecations_as_errors: true
 
 platforms:

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -51,12 +51,9 @@ module Ark
       new_resource.version = defaults.version
       new_resource.owner = defaults.owner
 
-      # TODO: what happens when the path is already set --
-      #   with the current logic we overwrite it
-      #   if you are in windows we overwrite it
-      #   otherwise we overwrite it with the root/name-version
-      new_resource.path = defaults.path
-      new_resource.release_file = defaults.release_file
+      # Calculate internal properties
+      new_resource._deploy_path = defaults.path
+      new_resource._release_file = defaults.release_file
     end
 
     def set_put_paths
@@ -65,13 +62,18 @@ module Ark
       # TODO: Should we be setting the prefix_root -
       #   as the prefix_root could be used in the path_with_version
       # new_resource.prefix_root = default.prefix_root
-      new_resource.path = defaults.path_without_version
-      new_resource.release_file = defaults.release_file_without_version
+
+      # Calculate internal properties
+      new_resource._deploy_path = defaults.path_without_version
+      new_resource._release_file = defaults.release_file_without_version
     end
 
     def set_dump_paths
       new_resource.extension = defaults.extension
-      new_resource.release_file = defaults.release_file_without_version
+
+      # Calculate internal properties
+      new_resource._deploy_path = new_resource.path
+      new_resource._release_file = defaults.release_file_without_version
     end
 
     def unpack_command

--- a/libraries/general_owner.rb
+++ b/libraries/general_owner.rb
@@ -7,7 +7,7 @@ module Ark
     attr_reader :resource
 
     def command
-      "chown -R #{resource.owner}:#{resource.group} #{resource.path}"
+      "chown -R #{resource.owner}:#{resource.group} #{resource._deploy_path}"
     end
   end
 end

--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -5,11 +5,11 @@ module Ark
     end
 
     def dump
-      sevenzip_command_builder(resource.path, 'e')
+      sevenzip_command_builder(resource._deploy_path, 'e')
     end
 
     def cherry_pick
-      "#{sevenzip_command_builder(resource.path, 'x')} -r #{resource.creates}"
+      "#{sevenzip_command_builder(resource._deploy_path, 'x')} -r #{resource.creates}"
     end
 
     def initialize(resource)
@@ -25,7 +25,7 @@ module Ark
     end
 
     def sevenzip_command
-      return sevenzip_command_builder(resource.path, 'x') if resource.strip_components <= 0
+      return sevenzip_command_builder(resource._deploy_path, 'x') if resource.strip_components <= 0
 
       tmpdir = make_temp_directory.tr('/', '\\')
       cmd = sevenzip_command_builder(tmpdir, 'x')
@@ -38,7 +38,7 @@ module Ark
         currdir += "\\%#{count}"
       end
 
-      cmd += "(\"#{ENV.fetch('SystemRoot')}\\System32\\robocopy\" \"#{currdir}\" \"#{resource.path}\" /s /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0"
+      cmd += "(\"#{ENV.fetch('SystemRoot')}\\System32\\robocopy\" \"#{currdir}\" \"#{resource._deploy_path}\" /s /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0"
     end
 
     def sevenzip_binary
@@ -57,7 +57,7 @@ module Ark
     end
 
     def sevenzip_command_builder(dir, command)
-      "#{sevenzip_binary} #{command} \"#{resource.release_file}\"#{extension_is_tar} -o\"#{dir}\" -uy"
+      "#{sevenzip_binary} #{command} \"#{resource._release_file}\"#{extension_is_tar} -o\"#{dir}\" -uy"
     end
 
     def extension_is_tar

--- a/libraries/tar_command_builder.rb
+++ b/libraries/tar_command_builder.rb
@@ -1,15 +1,15 @@
 module Ark
   class TarCommandBuilder
     def unpack
-      "#{tar_binary} #{args} #{resource.release_file}#{strip_args}"
+      "#{tar_binary} #{args} #{resource._release_file}#{strip_args}"
     end
 
     def dump
-      "tar -mxf \"#{resource.release_file}\" -C \"#{resource.path}\""
+      "tar -mxf \"#{resource._release_file}\" -C \"#{resource._deploy_path}\""
     end
 
     def cherry_pick
-      "#{tar_binary} #{args} #{resource.release_file} -C #{resource.path} #{resource.creates}#{strip_args}"
+      "#{tar_binary} #{args} #{resource._release_file} -C #{resource._deploy_path} #{resource.creates}#{strip_args}"
     end
 
     def initialize(resource)

--- a/libraries/unzip_command_builder.rb
+++ b/libraries/unzip_command_builder.rb
@@ -4,21 +4,21 @@ module Ark
       if resource.strip_components > 0
         unzip_with_strip_components
       else
-        "unzip -q -o #{resource.release_file} -d #{resource.path}"
+        "unzip -q -o #{resource._release_file} -d #{resource._deploy_path}"
       end
     end
 
     def dump
-      "unzip  -j -q -o \"#{resource.release_file}\" -d \"#{resource.path}\""
+      "unzip  -j -q -o \"#{resource._release_file}\" -d \"#{resource._deploy_path}\""
     end
 
     def cherry_pick
-      cmd = "unzip -t #{resource.release_file} \"*/#{resource.creates}\" ; stat=$? ;"
+      cmd = "unzip -t #{resource._release_file} \"*/#{resource.creates}\" ; stat=$? ;"
       cmd += 'if [ $stat -eq 11 ] ; then '
-      cmd += "unzip  -j -o #{resource.release_file} \"#{resource.creates}\" -d #{resource.path} ;"
+      cmd += "unzip  -j -o #{resource._release_file} \"#{resource.creates}\" -d #{resource._deploy_path} ;"
       cmd += 'elif [ $stat -ne 0 ] ; then false ;'
       cmd += 'else '
-      cmd += "unzip  -j -o #{resource.release_file} \"*/#{resource.creates}\" -d #{resource.path} ;"
+      cmd += "unzip  -j -o #{resource._release_file} \"*/#{resource.creates}\" -d #{resource._deploy_path} ;"
       cmd += 'fi'
       cmd
     end
@@ -34,8 +34,8 @@ module Ark
     def unzip_with_strip_components
       tmpdir = make_temp_directory
       strip_dir = '*/' * resource.strip_components
-      cmd = "unzip -q -o #{resource.release_file} -d #{tmpdir}"
-      cmd += " && rsync -a #{tmpdir}/#{strip_dir} #{resource.path}"
+      cmd = "unzip -q -o #{resource._release_file} -d #{tmpdir}"
+      cmd += " && rsync -a #{tmpdir}/#{strip_dir} #{resource._deploy_path}"
       cmd += " && rm -rf #{tmpdir}"
       cmd
     end

--- a/libraries/windows_owner.rb
+++ b/libraries/windows_owner.rb
@@ -7,7 +7,7 @@ module Ark
     attr_reader :resource
 
     def command
-      "#{ENV.fetch('SystemRoot')}\\System32\\icacls \"#{resource.path}\\*\" /setowner \"#{resource.owner}\""
+      "#{ENV.fetch('SystemRoot')}\\System32\\icacls \"#{resource._deploy_path}\\*\" /setowner \"#{resource.owner}\""
     end
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -23,12 +23,10 @@ property :owner, String
 property :group, [String, Integer], default: 0
 property :url, String, required: true
 property :path, String
-property :full_path, String
 property :append_env_path, [true, false], default: false
 property :checksum, regex: /^[a-zA-Z0-9]{64}$/, default: nil
 property :has_binaries, Array, default: []
 property :creates, String
-property :release_file, String, default: ''
 property :strip_leading_dir, [true, false, NilClass]
 property :strip_components, Integer, default: 1
 property :mode, [Integer, String], default: 0755
@@ -46,6 +44,10 @@ property :autoconf_opts, Array, default: []
 property :extension, String
 property :backup, [FalseClass, Integer], default: 5
 
+# Internal properties (overwritten by ark's actions)
+property :_deploy_path, String
+property :_release_file, String
+
 #################
 # action :install
 #################
@@ -53,32 +55,32 @@ action :install do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
     backup new_resource.backup
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
@@ -88,7 +90,7 @@ action :install do
     # so ignore has_binaries for now
 
     # Add to PATH permanently on Windows if append_env_path
-    windows_path "#{new_resource.path}/bin" do
+    windows_path "#{new_resource._deploy_path}/bin" do
       action :add
       only_if { new_resource.append_env_path }
     end
@@ -96,13 +98,13 @@ action :install do
     # symlink binaries
     new_resource.has_binaries.each do |bin|
       link ::File.join(new_resource.prefix_bin, ::File.basename(bin)) do
-        to ::File.join(new_resource.path, bin)
+        to ::File.join(new_resource._deploy_path, bin)
       end
     end
 
     # action_link_paths
     link new_resource.home_dir do
-      to new_resource.path
+      to new_resource._deploy_path
     end
 
     # Add to path for interactive bash sessions
@@ -113,13 +115,13 @@ action :install do
       group node['root_group']
       mode '0755'
       cookbook 'ark'
-      variables(directory: "#{new_resource.path}/bin")
+      variables(directory: "#{new_resource._deploy_path}/bin")
       only_if { new_resource.append_env_path }
     end
   end
 
   # Add to path for the current chef-client converge.
-  bin_path = ::File.join(new_resource.path, 'bin')
+  bin_path = ::File.join(new_resource._deploy_path, 'bin')
   ruby_block "adding '#{bin_path}' to chef-client ENV['PATH']" do
     block do
       ENV['PATH'] = bin_path + ':' + ENV['PATH']
@@ -137,32 +139,32 @@ action :put do
   show_deprecations
   set_put_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # download
-  remote_file new_resource.release_file do
+  remote_file new_resource._release_file do
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
     backup new_resource.backup
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
@@ -175,32 +177,32 @@ action :dump do
   show_deprecations
   set_dump_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # download
-  remote_file new_resource.release_file do
-    Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
+  remote_file new_resource._release_file do
+    Chef::Log.debug("DEBUG: new_resource._release_file #{new_resource._release_file}")
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command dump_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
@@ -213,32 +215,32 @@ action :unzip do
   show_deprecations
   set_dump_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # download
-  remote_file new_resource.release_file do
-    Chef::Log.debug("DEBUG: new_resource.release_file #{new_resource.release_file}")
+  remote_file new_resource._release_file do
+    Chef::Log.debug("DEBUG: new_resource._release_file #{new_resource._release_file}")
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unzip_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
@@ -252,29 +254,29 @@ action :cherry_pick do
   set_dump_paths
   Chef::Log.debug("DEBUG: new_resource.creates #{new_resource.creates}")
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
+    notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource._release_file}]"
   end
 
   # download
-  remote_file new_resource.release_file do
+  remote_file new_resource._release_file do
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource.release_file}]"
+    notifies :run, "execute[cherry_pick #{new_resource.creates} from #{new_resource._release_file}]"
   end
 
-  execute "cherry_pick #{new_resource.creates} from #{new_resource.release_file}" do
+  execute "cherry_pick #{new_resource.creates} from #{new_resource._release_file}" do
     command cherry_pick_command
-    creates "#{new_resource.path}/#{new_resource.creates}"
-    notifies :run, "execute[set owner on #{new_resource.path}]"
+    creates "#{new_resource._deploy_path}/#{new_resource.creates}"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
@@ -287,66 +289,66 @@ action :install_with_make do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
-    notifies :run, "execute[autogen #{new_resource.path}]"
-    notifies :run, "execute[configure #{new_resource.path}]"
-    notifies :run, "execute[make #{new_resource.path}]"
-    notifies :run, "execute[make install #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
+    notifies :run, "execute[autogen #{new_resource._deploy_path}]"
+    notifies :run, "execute[configure #{new_resource._deploy_path}]"
+    notifies :run, "execute[make #{new_resource._deploy_path}]"
+    notifies :run, "execute[make install #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
 
-  execute "autogen #{new_resource.path}" do
+  execute "autogen #{new_resource._deploy_path}" do
     command './autogen.sh'
-    only_if { ::File.exist? "#{new_resource.path}/autogen.sh" }
-    cwd new_resource.path
+    only_if { ::File.exist? "#{new_resource._deploy_path}/autogen.sh" }
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
     ignore_failure true
   end
 
-  execute "configure #{new_resource.path}" do
+  execute "configure #{new_resource._deploy_path}" do
     command "./configure #{new_resource.autoconf_opts.join(' ')}"
-    only_if { ::File.exist? "#{new_resource.path}/configure" }
-    cwd new_resource.path
+    only_if { ::File.exist? "#{new_resource._deploy_path}/configure" }
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
 
-  execute "make #{new_resource.path}" do
+  execute "make #{new_resource._deploy_path}" do
     command "make #{new_resource.make_opts.join(' ')}"
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
 
-  execute "make install #{new_resource.path}" do
+  execute "make install #{new_resource._deploy_path}" do
     command "make install #{new_resource.make_opts.join(' ')}"
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
@@ -356,39 +358,39 @@ action :setup_py_build do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
-    notifies :run, "execute[python setup.py build #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
+    notifies :run, "execute[python setup.py build #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
 
-  execute "python setup.py build #{new_resource.path}" do
+  execute "python setup.py build #{new_resource._deploy_path}" do
     command "python setup.py build #{new_resource.make_opts.join(' ')}"
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
@@ -398,39 +400,39 @@ action :setup_py_install do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
-    notifies :run, "execute[python setup.py install #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
+    notifies :run, "execute[python setup.py install #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
 
-  execute "python setup.py install #{new_resource.path}" do
+  execute "python setup.py install #{new_resource._deploy_path}" do
     command "python setup.py install #{new_resource.make_opts.join(' ')}"
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
@@ -440,39 +442,39 @@ action :setup_py do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
-    notifies :run, "execute[python setup.py #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
+    notifies :run, "execute[python setup.py #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
 
-  execute "python setup.py #{new_resource.path}" do
+  execute "python setup.py #{new_resource._deploy_path}" do
     command "python setup.py #{new_resource.make_opts.join(' ')}"
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end
@@ -482,50 +484,50 @@ action :configure do
   show_deprecations
   set_paths
 
-  directory new_resource.path do
+  directory new_resource._deploy_path do
     recursive true
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
-  remote_file new_resource.release_file do
-    Chef::Log.debug('DEBUG: new_resource.release_file')
+  remote_file new_resource._release_file do
+    Chef::Log.debug('DEBUG: new_resource._release_file')
     source new_resource.url
     checksum new_resource.checksum if new_resource.checksum
     action :create
-    notifies :run, "execute[unpack #{new_resource.release_file}]"
+    notifies :run, "execute[unpack #{new_resource._release_file}]"
   end
 
   # unpack based on file extension
-  execute "unpack #{new_resource.release_file}" do
+  execute "unpack #{new_resource._release_file}" do
     command unpack_command
-    cwd new_resource.path
+    cwd new_resource._deploy_path
     environment new_resource.environment
-    notifies :run, "execute[set owner on #{new_resource.path}]"
-    notifies :run, "execute[autogen #{new_resource.path}]"
-    notifies :run, "execute[configure #{new_resource.path}]"
+    notifies :run, "execute[set owner on #{new_resource._deploy_path}]"
+    notifies :run, "execute[autogen #{new_resource._deploy_path}]"
+    notifies :run, "execute[configure #{new_resource._deploy_path}]"
     action :nothing
   end
 
   # set_owner
-  execute "set owner on #{new_resource.path}" do
+  execute "set owner on #{new_resource._deploy_path}" do
     command owner_command
     action :nothing
   end
 
-  execute "autogen #{new_resource.path}" do
+  execute "autogen #{new_resource._deploy_path}" do
     command './autogen.sh'
-    only_if { ::File.exist? "#{new_resource.path}/autogen.sh" }
-    cwd new_resource.path
+    only_if { ::File.exist? "#{new_resource._deploy_path}/autogen.sh" }
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
     ignore_failure true
   end
 
-  execute "configure #{new_resource.path}" do
+  execute "configure #{new_resource._deploy_path}" do
     command "./configure #{new_resource.autoconf_opts.join(' ')}"
-    only_if { ::File.exist? "#{new_resource.path}/configure" }
-    cwd new_resource.path
+    only_if { ::File.exist? "#{new_resource._deploy_path}/configure" }
+    cwd new_resource._deploy_path
     environment new_resource.environment
     action :nothing
   end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/default.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/default.rb
@@ -4,10 +4,22 @@ include_recipe 'ark'
 
 # remove file so we can test sending notification on its creation
 FileUtils.rm_f '/tmp/foobarbaz/foo1.txt' if ::File.exist? '/tmp/foobarbaz/foo1.txt'
+FileUtils.rm_f '/tmp/foobarbaz/foo1_before.txt' if ::File.exist? '/tmp/foobarbaz/foo1_before.txt'
 
 ruby_block 'test_notification' do
   block do
-    FileUtils.touch '/tmp/foobarbaz/notification_successful.txt' if ::File.exist? '/tmp/foobarbaz/foo1.txt'
+    if ::File.exist? '/tmp/foobarbaz/foo1.txt'
+      FileUtils.touch '/tmp/foobarbaz/notification_successful.txt'
+    end
+  end
+  action :nothing
+end
+
+ruby_block 'test_notification_before' do
+  block do
+    if ::File.exist? '/tmp/foobarbaz_before/foo1.txt'
+      FileUtils.touch '/tmp/foobarbaz_before/notification_successful.txt'
+    end
   end
   action :nothing
 end
@@ -92,13 +104,15 @@ ark 'foo_zip_strip' do
   action :install
 end
 
-ark 'haproxy' do
-  url 'http://haproxy.1wt.eu/download/1.5/src/snapshot/haproxy-ss-20120403.tar.gz'
-  version '1.5'
-  checksum 'ba0424bf7d23b3a607ee24bbb855bb0ea347d7ffde0bec0cb12a89623cbaf911'
-  make_opts ['TARGET=linux26']
-  action :install_with_make
-end unless platform?('freebsd')
+unless platform?('freebsd')
+  ark 'haproxy' do
+    url 'http://haproxy.1wt.eu/download/1.5/src/snapshot/haproxy-ss-20120403.tar.gz'
+    version '1.5'
+    checksum 'ba0424bf7d23b3a607ee24bbb855bb0ea347d7ffde0bec0cb12a89623cbaf911'
+    make_opts ['TARGET=linux26']
+    action :install_with_make
+  end
+end
 
 ark 'foo_alt_bin' do
   url 'https://github.com/burtlo/ark/raw/master/files/default/foo.tar.gz'
@@ -136,6 +150,14 @@ ark 'test_notification' do
   creates 'foo1.txt'
   action :dump
   notifies :create, 'ruby_block[test_notification]', :immediately
+end
+
+ark 'test_notification_before' do
+  url 'https://github.com/burtlo/ark/raw/master/files/default/foo.zip'
+  path '/tmp/foobarbaz_before'
+  creates 'foo1.txt'
+  action :dump
+  notifies :create, 'ruby_block[test_notification_before]', :before
 end
 
 ark 'test_autogen' do

--- a/spec/fixtures/cookbooks/ark_spec/recipes/dump_notifies_before.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/dump_notifies_before.rb
@@ -1,0 +1,15 @@
+file '/tmp/ark_notify_before_received' do
+  content 'ark_notify_before_received'
+  action :nothing
+end
+
+ark 'test_dump_notifies_before' do
+  url 'https://github.com/burtlo/ark/raw/master/files/default/foo.zip'
+  checksum 'deea3a324115c9ca0f3078362f807250080bf1b27516f7eca9d34aad863a11e0'
+  path '/usr/local/foo_dump'
+  creates 'foo1.txt'
+  owner 'foobarbaz'
+  group 'foobarbaz'
+  action :dump
+  notifies :create, 'file[/tmp/ark_notify_before_received]', :before
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/install_notifies_before.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/install_notifies_before.rb
@@ -1,0 +1,15 @@
+file '/tmp/ark_notify_before_received' do
+  content 'ark_notify_before_received'
+  action :nothing
+end
+
+ark 'test_install_notifies_before' do
+  url 'https://github.com/burtlo/ark/raw/master/files/default/foo.tar.gz'
+  checksum '5996e676f17457c823d86f1605eaa44ca8a81e70d6a0e5f8e45b51e62e0c52e8'
+  version '2'
+  prefix_root '/usr/local'
+  owner 'foobarbaz'
+  group 'foobarbaz_group'
+  action :install
+  notifies :create, 'file[/tmp/ark_notify_before_received]', :before
+end

--- a/spec/fixtures/cookbooks/ark_spec/recipes/put_notifies_before.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/put_notifies_before.rb
@@ -1,0 +1,13 @@
+file '/tmp/ark_notify_before_received' do
+  content 'ark_notify_before_received'
+  action :nothing
+end
+
+ark 'test_put_notifies_before' do
+  url 'https://github.com/burtlo/ark/raw/master/files/default/foo.tar.gz'
+  checksum '5996e676f17457c823d86f1605eaa44ca8a81e70d6a0e5f8e45b51e62e0c52e8'
+  owner 'foobarbaz'
+  group 'foobarbaz_group'
+  action :put
+  notifies :create, 'file[/tmp/ark_notify_before_received]', :before
+end

--- a/spec/libraries/default_spec.rb
+++ b/spec/libraries/default_spec.rb
@@ -12,7 +12,7 @@ describe_helpers Ark::ProviderHelpers do
     context 'when on windows' do
       it 'generates a icacls command' do
         with_node_attributes(platform_family: 'windows')
-        with_resource_properties(owner: 'Bobo', path: 'C:\\temp')
+        with_resource_properties(owner: 'Bobo', _deploy_path: 'C:\\temp')
 
         expect(owner_command).to eq('C:\\Windows\\System32\\icacls "C:\\temp\\*" /setowner "Bobo"')
       end
@@ -20,7 +20,7 @@ describe_helpers Ark::ProviderHelpers do
 
     context 'when not on windows' do
       it 'generates a chown command' do
-        with_resource_properties(owner: 'MouseTrap', group: 'RatCatchers', path: '/opt/rathole')
+        with_resource_properties(owner: 'MouseTrap', group: 'RatCatchers', _deploy_path: '/opt/rathole')
 
         expect(owner_command).to eq('chown -R MouseTrap:RatCatchers /opt/rathole')
       end
@@ -55,7 +55,7 @@ describe_helpers Ark::ProviderHelpers do
     it "sets the resource's release_file" do
       with_resource_properties(extension: 'tar.gz', name: 'what_is_a_good_name')
       set_dump_paths
-      expect(new_resource.release_file).to eq('/var/chef/cache/what_is_a_good_name.tar.gz')
+      expect(new_resource._release_file).to eq('/var/chef/cache/what_is_a_good_name.tar.gz')
     end
   end
 
@@ -66,12 +66,12 @@ describe_helpers Ark::ProviderHelpers do
         allow(defaults).to receive(:prefix_root_from_node_in_run_context) { '/opt/default' }
         set_put_paths
 
-        expect(new_resource.release_file).to eq('/var/chef/cache/gustav-moomoo.jar')
+        expect(new_resource._release_file).to eq('/var/chef/cache/gustav-moomoo.jar')
       end
     end
 
     context 'when the resource path has been set' do
-      it "sets the resource's release_file and path" do
+      it "sets the resource's _release_file and _deploy_path" do
         with_resource_properties(
           extension: 'jar',
           name: 'gustav-tootoo',
@@ -79,8 +79,8 @@ describe_helpers Ark::ProviderHelpers do
         )
         set_put_paths
 
-        expect(new_resource.release_file).to eq('/var/chef/cache/gustav-tootoo.jar')
-        expect(new_resource.path).to eq('/path/piece/gustav-tootoo')
+        expect(new_resource._release_file).to eq('/var/chef/cache/gustav-tootoo.jar')
+        expect(new_resource._deploy_path).to eq('/path/piece/gustav-tootoo')
       end
     end
   end
@@ -98,7 +98,7 @@ describe_helpers Ark::ProviderHelpers do
 
       set_paths
 
-      expect(new_resource.release_file).to eq('/var/chef/cache/resource_name-99.jar')
+      expect(new_resource._release_file).to eq('/var/chef/cache/resource_name-99.jar')
     end
 
     it "sets the resource's release_file" do
@@ -118,7 +118,7 @@ describe_helpers Ark::ProviderHelpers do
 
       chef_config_file_cache_path = '/var/chef/cache'
 
-      expect(new_resource.release_file).to eq("#{chef_config_file_cache_path}/resource_name-23.jar")
+      expect(new_resource._release_file).to eq("#{chef_config_file_cache_path}/resource_name-23.jar")
     end
   end
 
@@ -130,9 +130,9 @@ describe_helpers Ark::ProviderHelpers do
         with_node_attributes(platform_family: 'windows')
         with_resource_properties(
           url: 'http://website.com/windows_package.zip',
-          path: '/resource/path',
+          _deploy_path: '/resource/path',
           creates: '/resource/creates',
-          release_file: '/resource/release_file',
+          _release_file: '/resource/release_file',
           run_context: double(node: { 'ark' => { 'tar' => 'sevenzip_command' } })
         )
 
@@ -145,9 +145,9 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a cherry pick tar command with the correct options' do
           with_resource_properties(
             url: 'http://website.com/package.tar.gz',
-            path: '/resource/path',
+            _deploy_path: '/resource/path',
             creates: '/resource/creates',
-            release_file: '/resource/release_file',
+            _release_file: '/resource/release_file',
             strip_components: 0,
             run_context: double(node: { 'ark' => { 'tar' => 'tar' } })
           )
@@ -160,9 +160,9 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a cherry pick tar command with the correct options' do
           with_resource_properties(
             url: 'http://website.com/package.tar.bz2',
-            path: '/resource/path',
+            _deploy_path: '/resource/path',
             creates: '/resource/creates',
-            release_file: '/resource/release_file',
+            _release_file: '/resource/release_file',
             strip_components: 0,
             run_context: double(node: { 'ark' => { 'tar' => 'tar' } })
           )
@@ -175,9 +175,9 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a cherry pick tar command with the correct options' do
           with_resource_properties(
             url: 'http://website.com/package.txz',
-            path: '/resource/path',
+            _deploy_path: '/resource/path',
             creates: '/resource/creates',
-            release_file: '/resource/release_file',
+            _release_file: '/resource/release_file',
             strip_components: 0,
             run_context: double(node: { 'ark' => { 'tar' => 'tar' } })
           )
@@ -190,9 +190,9 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates an unzip command' do
           with_resource_properties(
             url: 'http://website.com/package.zip',
-            path: '/resource/path',
+            _deploy_path: '/resource/path',
             creates: '/resource/creates',
-            release_file: '/resource/release_file',
+            _release_file: '/resource/release_file',
             run_context: double(node: { 'ark' => { 'tar' => 'unzip_command' } })
           )
 
@@ -213,8 +213,8 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a tar command' do
           with_resource_properties(
             url: 'http://website.com/package.tgz',
-            release_file: '/resource/release_file',
-            path: '/resource/path'
+            _release_file: '/resource/release_file',
+            _deploy_path: '/resource/path'
           )
 
           expect(dump_command).to eq('tar -mxf "/resource/release_file" -C "/resource/path"')
@@ -225,8 +225,8 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a tar command' do
           with_resource_properties(
             url: 'http://website.com/package.tbz',
-            release_file: '/resource/release_file',
-            path: '/resource/path'
+            _release_file: '/resource/release_file',
+            _deploy_path: '/resource/path'
           )
 
           expect(dump_command).to eq('tar -mxf "/resource/release_file" -C "/resource/path"')
@@ -237,8 +237,8 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates a tar command' do
           with_resource_properties(
             url: 'http://website.com/package.tar.xz',
-            release_file: '/resource/release_file',
-            path: '/resource/path'
+            _release_file: '/resource/release_file',
+            _deploy_path: '/resource/path'
           )
 
           expect(dump_command).to eq('tar -mxf "/resource/release_file" -C "/resource/path"')
@@ -249,8 +249,8 @@ describe_helpers Ark::ProviderHelpers do
         it 'generates an unzip command' do
           with_resource_properties(
             url: 'http://website.com/package.jar',
-            release_file: '/resource/release_file',
-            path: '/resource/path'
+            _release_file: '/resource/release_file',
+            _deploy_path: '/resource/path'
           )
 
           expect(dump_command).to eq('unzip  -j -q -o "/resource/release_file" -d "/resource/path"')

--- a/spec/libraries/general_owner_spec.rb
+++ b/spec/libraries/general_owner_spec.rb
@@ -7,7 +7,7 @@ describe Ark::GeneralOwner do
   let(:resource) do
     double(owner: 'owner',
            group: 'group',
-           path: '/resource/path')
+           _deploy_path: '/resource/path')
   end
 
   it 'generates the correct command for windows file ownership' do

--- a/spec/libraries/sevenzip_command_builder_spec.rb
+++ b/spec/libraries/sevenzip_command_builder_spec.rb
@@ -5,9 +5,9 @@ describe Ark::SevenZipCommandBuilder do
   let(:subject) { described_class.new(resource) }
 
   let(:resource) do
-    double(release_file: 'release_file',
+    double(_release_file: 'release_file',
            creates: 'creates',
-           path: 'path',
+           _deploy_path: 'path',
            home_dir: 'home_dir',
            strip_components: 1,
            extension: 'tar.gz')

--- a/spec/libraries/tar_command_builder_spec.rb
+++ b/spec/libraries/tar_command_builder_spec.rb
@@ -5,9 +5,9 @@ describe Ark::TarCommandBuilder do
   let(:subject) { described_class.new(resource) }
 
   let(:resource) do
-    double(release_file: 'release_file',
+    double(_release_file: 'release_file',
            creates: 'creates',
-           path: 'path',
+           _deploy_path: 'path',
            strip_components: 1,
            extension: 'tar.gz')
   end
@@ -26,9 +26,9 @@ describe Ark::TarCommandBuilder do
 
     context 'when the extension is tar (only tar)' do
       let(:resource) do
-        double(release_file: 'release_file',
+        double(_release_file: 'release_file',
                creates: 'creates',
-               path: 'path',
+               _deploy_path: 'path',
                strip_components: 1,
                extension: 'tar')
       end
@@ -41,10 +41,10 @@ describe Ark::TarCommandBuilder do
 
     context 'when the extension is not supported' do
       let(:resource) do
-        double(release_file: 'release_file',
+        double(_release_file: 'release_file',
                url: 'http://website.com/files/content.stuffit',
                creates: 'creates',
-               path: 'path',
+               _deploy_path: 'path',
                strip_components: 1,
                extension: 'stuffit')
       end

--- a/spec/libraries/unzip_command_builder_spec.rb
+++ b/spec/libraries/unzip_command_builder_spec.rb
@@ -5,9 +5,9 @@ describe Ark::UnzipCommandBuilder do
   let(:subject) { described_class.new(resource) }
 
   let(:resource) do
-    double(release_file: 'release_file',
+    double(_release_file: 'release_file',
            creates: 'creates',
-           path: 'path',
+           _deploy_path: 'path',
            strip_components: 0)
   end
 
@@ -21,9 +21,9 @@ describe Ark::UnzipCommandBuilder do
 
     context 'when the resource does strip components' do
       let(:resource) do
-        double(release_file: 'release_file',
+        double(_release_file: 'release_file',
                creates: 'creates',
-               path: 'path',
+               _deploy_path: 'path',
                strip_components: 1)
       end
 

--- a/spec/libraries/windows_owner_spec.rb
+++ b/spec/libraries/windows_owner_spec.rb
@@ -4,7 +4,7 @@ require './libraries/default'
 describe Ark::WindowsOwner do
   let(:subject) { described_class.new(resource) }
 
-  let(:resource) { double(path: 'c:\\resource with spaces\\path', owner: 'the new owner') }
+  let(:resource) { double(_deploy_path: 'c:\\resource with spaces\\path', owner: 'the new owner') }
 
   before(:each) do
     allow(ENV).to receive(:fetch).and_call_original

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -165,6 +165,33 @@ describe_resource 'ark' do
     end
   end
 
+  describe 'install with notifies :before' do
+    let(:example_recipe) { 'ark_spec::install_notifies_before' }
+
+    it 'installs' do
+      expect(chef_run).to install_ark('test_install_notifies_before')
+      resource = chef_run.ark('test_install_notifies_before')
+      expect(resource).to notify('file[/tmp/ark_notify_before_received]').to(:create).before
+
+      expect(chef_run).to create_directory('/usr/local/test_install_notifies_before-2')
+      resource = chef_run.directory('/usr/local/test_install_notifies_before-2')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_install_notifies_before-2.tar.gz]').to(:run)
+
+      expect(chef_run).to create_remote_file('/var/chef/cache/test_install_notifies_before-2.tar.gz')
+      resource = chef_run.remote_file('/var/chef/cache/test_install_notifies_before-2.tar.gz')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_install_notifies_before-2.tar.gz]').to(:run)
+
+      expect(chef_run).not_to run_execute('unpack /var/chef/cache/test_install_notifies_before-2.tar.gz')
+      resource = chef_run.execute('unpack /var/chef/cache/test_install_notifies_before-2.tar.gz')
+      expect(resource).to notify('execute[set owner on /usr/local/test_install_notifies_before-2]').to(:run)
+
+      expect(chef_run).not_to create_file('/tmp/ark_notify_before_received')
+      expect(chef_run).not_to run_execute('set owner on /usr/local/test_install_notifies_before-2')
+      expect(chef_run).not_to create_template('/etc/profile.d/test_install_notifies_before.sh')
+      expect(chef_run).not_to run_ruby_block("adding '/usr/local/test_install_notifies_before-2/bin' to chef-client ENV['PATH']")
+    end
+  end
+
   describe 'put' do
     let(:example_recipe) { 'ark_spec::put' }
 
@@ -184,6 +211,28 @@ describe_resource 'ark' do
     end
   end
 
+  describe 'put with notifies :before' do
+    let(:example_recipe) { 'ark_spec::put_notifies_before' }
+
+    it 'puts_notifies_before' do
+      expect(chef_run).to put_ark('test_put_notifies_before')
+      resource = chef_run.ark('test_put_notifies_before')
+      expect(resource).to notify('file[/tmp/ark_notify_before_received]').to(:create).before
+
+      expect(chef_run).to create_directory('/usr/local/test_put_notifies_before')
+      resource = chef_run.directory('/usr/local/test_put_notifies_before')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_put_notifies_before.tar.gz]').to(:run)
+
+      expect(chef_run).to create_remote_file('/var/chef/cache/test_put_notifies_before.tar.gz')
+      resource = chef_run.remote_file('/var/chef/cache/test_put_notifies_before.tar.gz')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_put_notifies_before.tar.gz]').to(:run)
+
+      expect(chef_run).to_not create_file('/tmp/ark_notify_before_received')
+      expect(chef_run).to_not run_execute('unpack /var/chef/cache/test_put_notifies_before.tar.gz')
+      expect(chef_run).to_not run_execute('set owner on /usr/local/test_put_notifies_before')
+    end
+  end
+
   describe 'dump' do
     let(:example_recipe) { 'ark_spec::dump' }
 
@@ -199,6 +248,28 @@ describe_resource 'ark' do
       expect(resource).to notify('execute[unpack /var/chef/cache/test_dump.zip]').to(:run)
 
       expect(chef_run).to_not run_execute('unpack /var/chef/cache/test_dump.zip')
+      expect(chef_run).to_not run_execute('set owner on /usr/local/foo_dump')
+    end
+  end
+
+  describe 'dump with notifies :before' do
+    let(:example_recipe) { 'ark_spec::dump_notifies_before' }
+
+    it 'dumps' do
+      expect(chef_run).to dump_ark('test_dump_notifies_before')
+      resource = chef_run.ark('test_dump_notifies_before')
+      expect(resource).to notify('file[/tmp/ark_notify_before_received]').to(:create).before
+
+      expect(chef_run).to create_directory('/usr/local/foo_dump')
+      resource = chef_run.directory('/usr/local/foo_dump')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_dump_notifies_before.zip]').to(:run)
+
+      expect(chef_run).to create_remote_file('/var/chef/cache/test_dump_notifies_before.zip')
+      resource = chef_run.remote_file('/var/chef/cache/test_dump_notifies_before.zip')
+      expect(resource).to notify('execute[unpack /var/chef/cache/test_dump_notifies_before.zip]').to(:run)
+
+      expect(chef_run).to_not create_file('/tmp/ark_notify_before_received')
+      expect(chef_run).to_not run_execute('unpack /var/chef/cache/test_dump_notifies_before.zip')
       expect(chef_run).to_not run_execute('set owner on /usr/local/foo_dump')
     end
   end


### PR DESCRIPTION
Signed-off-by: Christophe Sourisse <christophe.sourisse@gmail.com>

### Description

Ark resource wasn't supporting whyrun mode because of its overwritting of resource attributes set by user recipes (especially the path attr).

Using constructs like `notifies :action, 'other_resource[name]', :before` would cause the path resource attribute to be calculated twice (and thus appended the resource name twice, as described in issue #196).

By introducing new "internal" resource attribute ("_deploy_path" and "_release_file"), which are set by and only by ark's resource internal implementation, this resource is now whyrun compliant and such notification constructs are now possible.

Example:

```ruby
service 'tomcat' do
  action :nothing
end
ark 'webapp' do
  [...]
  notifies :stop, 'service[tomcat]', :before
end
```

### Issues Resolved

- #196 : Notfies :before property doubles the leaf-directory

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
