### PR TITLE
Chef 17 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the ark cookbook.
 
 ## Unreleased
 
+- Chef 17 updates: enable `unified_mode` on all resources
+- Bump required Chef Infra Client to >= 15.3
+- Migrate to using `seven_zip_tool` resource directly and require `seven_zip` >= 3.1
+- Various ChefSpec fixes
+
 ## 5.1.1 - *2021-04-29*
 
 - Added a version pin on seven_zip

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Provides a custom resource for installing runtime artifacts i
 version           '5.1.1'
 source_url        'https://github.com/sous-chefs/ark'
 issues_url        'https://github.com/sous-chefs/ark/issues'
-chef_version      '>= 14.0'
+chef_version      '>= 15.3'
 
 supports 'amazon'
 supports 'centos'
@@ -23,4 +23,4 @@ supports 'suse'
 supports 'ubuntu'
 supports 'windows'
 
-depends 'seven_zip', '~> 3.2.0' # for windows os
+depends 'seven_zip', '>= 3.1' # for windows os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,4 +20,4 @@
 
 package node['ark']['package_dependencies'] unless platform_family?('windows', 'mac_os_x')
 
-include_recipe 'seven_zip' if platform_family?('windows')
+seven_zip_tool 'ark' if platform_family?('windows')

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -46,6 +46,8 @@ property :autoconf_opts, Array, default: []
 property :extension, String
 property :backup, [FalseClass, Integer], default: 5
 
+unified_mode true
+
 #################
 # action :install
 #################

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -11,8 +11,8 @@ describe_recipe 'ark::default' do
     expect(chef_run).not_to install_package('gcc-c++')
   end
 
-  it 'does not include the seven_zip recipe' do
-    expect(chef_run).not_to include_recipe('seven_zip')
+  it do
+    expect(chef_run).not_to install_seven_zip_tool 'ark'
   end
 
   context 'sets default attributes' do

--- a/spec/recipes/windows/default_spec.rb
+++ b/spec/recipes/windows/default_spec.rb
@@ -5,7 +5,7 @@ describe_recipe 'ark::default' do
     { platform: 'windows' }
   end
 
-  it 'does include the 7-zip recipe' do
-    expect(chef_run).to include_recipe('seven_zip')
+  it do
+    expect(chef_run).to install_seven_zip_tool 'ark'
   end
 end

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -136,7 +136,7 @@ describe_resource 'ark' do
     end
 
     def node_attributes
-      { platform: 'windows', version: '2008R2' }
+      { platform: 'windows', version: '10' }
     end
 
     it 'installs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
   config.alias_example_group_to :describe_helpers, type: :helpers
   config.alias_example_group_to :describe_resource, type: :resource
   config.file_cache_path = '/var/chef/cache'
-  config.log_level = :fatal
+  config.log_level = :warn
   config.platform = 'ubuntu'
 end
 


### PR DESCRIPTION
This resolves #234

- Chef 17 updates: enable `unified_mode` on all resources
- Bump required Chef Infra Client to >= 15.3
- Migrate to using `seven_zip_tool` resource directly and require `seven_zip` >= 3.1
- Various ChefSpec fixes

Signed-off-by: Lance Albertson <lance@osuosl.org>
