### PR TITLE
Update tested platforms + remove Delivery

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,48 +8,28 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
-          - 'amazonlinux-2'
-          - 'debian-9'
-          - 'debian-10'
-          - 'centos-7'
-          - 'centos-8'
-          - 'fedora-latest'
-          - 'ubuntu-1804'
-          - 'ubuntu-2004'
+          - almalinux-8
+          - amazonlinux-2
+          - centos-7
+          - centos-stream-8
+          - debian-10
+          - debian-11
+          - fedora-latest
+          - opensuse-leap-15
+          - rockylinux-8
+          - ubuntu-1804
+          - ubuntu-2004
         suite:
-          - 'default'
+          - default
       fail-fast: false
 
     steps:
@@ -66,16 +46,15 @@ jobs:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
 
-
   integration-windows:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: windows-latest
     strategy:
       matrix:
         os:
-          - 'windows-latest'
+          - windows-latest
         suite:
-          - 'windows'
+          - windows
       fail-fast: false
 
     steps:
@@ -93,14 +72,14 @@ jobs:
           os: ${{ matrix.os }}
 
   integration-macos:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: macos-latest
     strategy:
       matrix:
         os:
-          - 'macos-latest'
+          - macos-latest
         suite:
-          - 'default'
+          - default
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the ark cookbook.
 
 ## Unreleased
 
+- Update tested platforms
+- Remove delivery and move to calling RSpec directly via a reusable workflow
+
 ## 6.0.3 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -11,33 +11,34 @@ provisioner:
   name: dokken
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
@@ -49,17 +50,18 @@ platforms:
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -6,7 +6,7 @@ transport:
   name: exec
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   deprecations_as_errors: true
 
 platforms:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,7 +2,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_infra
   product_name: chef
   deprecations_as_errors: true
   chef_license: accept-no-persist
@@ -11,22 +11,24 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
   - name: fedora-latest
   - name: freebsd-12
   - name: opensuse-leap-15
+  - name: rockylinux-8
+  - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: sles-12-sp1
     driver:
       box: chef/sles-12-sp1-x86_64  # private box
   - name: solaris-11.3
     driver:
       box: chef/solaris-11.3  # private box
-  - name: ubuntu-16.04
-  - name: ubuntu-18.04
   - name: windows-2012r2
     driver:
       box: tas50/windows_2012r2


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

- Remove CentOS 8, Debian 9 & Ubuntu 16.04
- Add CentOS Stream 8, Alma Linux 8, Rocky Linux 8, Debian 11
- Switch Delivery to reusable GHA workflow

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
