### PR TITLE
fix: add require 'ostruct' for Ruby 3.2+ compatibility

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'chefspec'
 require 'chefspec/berkshelf'
 


### PR DESCRIPTION
Ruby 3.2+ no longer auto-loads OpenStruct. The spec_helper uses OpenStruct for test doubles but was missing the explicit require, causing all 19 library specs to fail.